### PR TITLE
Remove `-Xmax-classfile-name`-option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ SbtPgp.autoImport.useGpg := true
 
 SbtPgp.autoImport.useGpgAgent := true
 
-scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8", "-Xmax-classfile-name", "254")
+scalacOptions := Seq("-unchecked", "-deprecation", "-feature", "-encoding", "utf8")
 
 fullClasspath in console in Compile ++= (fullClasspath in Test).value // because that's where "PluginRunner" is
 


### PR DESCRIPTION
This was uncovered in the community build for scala 2.13.0-RC1, see scala/bug#11453